### PR TITLE
[codex] Sync CUDA Neovim config

### DIFF
--- a/nvim/lazyvim.json
+++ b/nvim/lazyvim.json
@@ -1,5 +1,6 @@
 {
   "extras": [
+    "lazyvim.plugins.extras.lang.clangd",
     "lazyvim.plugins.extras.lang.typescript",
     "lazyvim.plugins.extras.lang.python",
     "lazyvim.plugins.extras.lang.go",

--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -1,3 +1,16 @@
 -- Autocmds are automatically loaded on the VeryLazy event
 -- Default autocmds that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/autocmds.lua
 -- Add any additional autocmds here
+vim.opt.swapfile = false
+
+require("config.cuda").setup()
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "cuda",
+  callback = function(event)
+    vim.bo[event.buf].commentstring = "// %s"
+    vim.bo[event.buf].shiftwidth = 2
+    vim.bo[event.buf].tabstop = 2
+    vim.bo[event.buf].expandtab = true
+  end,
+})

--- a/nvim/lua/config/cuda.lua
+++ b/nvim/lua/config/cuda.lua
@@ -1,0 +1,210 @@
+local M = {}
+
+local commands_created = false
+
+local function path_exists(path)
+  return path and vim.uv.fs_stat(path) ~= nil
+end
+
+local function project_root(path)
+  local current = path
+  if not current or current == "" then
+    current = vim.api.nvim_buf_get_name(0)
+  end
+
+  local start = current ~= "" and vim.fs.dirname(current) or vim.uv.cwd()
+  local root = vim.fs.find({ "pixi.toml", "Justfile", ".clangd", ".git" }, {
+    path = start,
+    upward = true,
+  })[1]
+
+  return root and vim.fs.dirname(root) or vim.uv.cwd()
+end
+
+local function relative_to_root(path, root)
+  if not path or path == "" then
+    return nil
+  end
+
+  local prefix = root .. "/"
+  if vim.startswith(path, prefix) then
+    return path:sub(#prefix + 1)
+  end
+
+  return path
+end
+
+local function current_kernel_name()
+  local path = vim.api.nvim_buf_get_name(0)
+  if path == "" then
+    return nil
+  end
+
+  local stem = vim.fn.fnamemodify(path, ":t:r")
+  if stem == "" then
+    return nil
+  end
+
+  return (stem:gsub("^test_", ""))
+end
+
+local function current_test_file()
+  local root = project_root()
+  local current = vim.api.nvim_buf_get_name(0)
+  local rel = relative_to_root(current, root)
+
+  if rel and rel:match("^tests/test_.+%.py$") then
+    return current
+  end
+
+  local kernel = current_kernel_name()
+  if not kernel then
+    return nil
+  end
+
+  local test_path = vim.fs.joinpath(root, "tests", "test_" .. kernel .. ".py")
+  return path_exists(test_path) and test_path or nil
+end
+
+local function open_terminal(cmd)
+  local root = project_root()
+  vim.cmd("botright 15split")
+  vim.fn.termopen({ "bash", "-lc", cmd }, { cwd = root })
+  vim.cmd("startinsert")
+end
+
+local function run_repo_command(cmd)
+  open_terminal(cmd)
+end
+
+function M.run_current_test()
+  local root = project_root()
+  local test_file = current_test_file()
+  if test_file then
+    run_repo_command("just test-cuda " .. vim.fn.shellescape(relative_to_root(test_file, root)))
+    return
+  end
+
+  local kernel = current_kernel_name()
+  if kernel then
+    run_repo_command("just test-cuda -- -k " .. vim.fn.shellescape(kernel))
+    return
+  end
+
+  vim.notify("Could not determine the CUDA kernel test for this buffer", vim.log.levels.WARN)
+end
+
+function M.run_all_tests()
+  run_repo_command("just test-all")
+end
+
+function M.verify_hardware()
+  run_repo_command("just verify-hw")
+end
+
+function M.debug_current_test()
+  local root = project_root()
+  local test_file = current_test_file()
+  if not test_file then
+    vim.notify("Open a CUDA source or matching pytest file first", vim.log.levels.WARN)
+    return
+  end
+
+  local python = vim.fs.joinpath(root, ".pixi", "envs", "benchmark", "bin", "python")
+  if not path_exists(python) then
+    python = "python"
+  end
+
+  local rel_test = relative_to_root(test_file, root)
+  local cmd = table.concat({
+    "CUDA_LAUNCH_BLOCKING=1",
+    "cuda-gdb --args",
+    vim.fn.shellescape(python),
+    "-m pytest -q",
+    vim.fn.shellescape(rel_test),
+  }, " ")
+
+  run_repo_command(cmd)
+end
+
+function M.open_alternate()
+  local root = project_root()
+  local current = vim.api.nvim_buf_get_name(0)
+  if current == "" then
+    vim.notify("Open a CUDA or pytest file first", vim.log.levels.WARN)
+    return
+  end
+
+  local kernel = current_kernel_name()
+  if not kernel then
+    vim.notify("Could not determine the current kernel name", vim.log.levels.WARN)
+    return
+  end
+
+  local rel = relative_to_root(current, root)
+  local candidates = {}
+
+  local function add(path)
+    if path ~= current and path_exists(path) then
+      candidates[#candidates + 1] = path
+    end
+  end
+
+  if rel and rel:match("^cuda/test_.+%.cu$") then
+    add(vim.fs.joinpath(root, "cuda", kernel .. ".cuh"))
+    add(vim.fs.joinpath(root, "tests", "test_" .. kernel .. ".py"))
+  elseif rel and rel:match("^cuda/.+%.cuh$") then
+    add(vim.fs.joinpath(root, "cuda", "test_" .. kernel .. ".cu"))
+    add(vim.fs.joinpath(root, "tests", "test_" .. kernel .. ".py"))
+  elseif rel and rel:match("^tests/test_.+%.py$") then
+    add(vim.fs.joinpath(root, "cuda", kernel .. ".cuh"))
+    add(vim.fs.joinpath(root, "cuda", "test_" .. kernel .. ".cu"))
+  end
+
+  if #candidates == 0 then
+    vim.notify("No alternate CUDA file found", vim.log.levels.INFO)
+    return
+  end
+
+  if #candidates == 1 then
+    vim.cmd.edit(vim.fn.fnameescape(candidates[1]))
+    return
+  end
+
+  vim.ui.select(candidates, {
+    prompt = "Open related CUDA file",
+    format_item = function(item)
+      return relative_to_root(item, root)
+    end,
+  }, function(choice)
+    if choice then
+      vim.cmd.edit(vim.fn.fnameescape(choice))
+    end
+  end)
+end
+
+function M.setup()
+  if commands_created then
+    return
+  end
+
+  commands_created = true
+
+  vim.api.nvim_create_user_command("CudaAlternate", M.open_alternate, {
+    desc = "Open the related CUDA or pytest file",
+  })
+  vim.api.nvim_create_user_command("CudaDebugCurrent", M.debug_current_test, {
+    desc = "Debug the current CUDA test with cuda-gdb",
+  })
+  vim.api.nvim_create_user_command("CudaTestAll", M.run_all_tests, {
+    desc = "Run the full CUDA pytest suite",
+  })
+  vim.api.nvim_create_user_command("CudaTestCurrent", M.run_current_test, {
+    desc = "Run the CUDA pytest for the current kernel",
+  })
+  vim.api.nvim_create_user_command("CudaVerifyHw", M.verify_hardware, {
+    desc = "Run the CUDA hardware verification helper",
+  })
+end
+
+return M

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -1,3 +1,10 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 -- Add any additional keymaps here
+local cuda = require("config.cuda")
+
+vim.keymap.set("n", "<leader>ma", cuda.open_alternate, { desc = "CUDA Alternate File" })
+vim.keymap.set("n", "<leader>md", cuda.debug_current_test, { desc = "CUDA Debug Current Test" })
+vim.keymap.set("n", "<leader>mh", cuda.verify_hardware, { desc = "CUDA Verify Hardware" })
+vim.keymap.set("n", "<leader>mt", cuda.run_current_test, { desc = "CUDA Test Current" })
+vim.keymap.set("n", "<leader>mT", cuda.run_all_tests, { desc = "CUDA Test All" })

--- a/nvim/lua/plugins/conform.lua
+++ b/nvim/lua/plugins/conform.lua
@@ -3,6 +3,7 @@ return {
   opts = {
     notify_on_error = false,
     formatters_by_ft = {
+      cuda = { "clang_format" },
       lua = { "stylua" },
       python = { "ruff" },
       rust = { "rustfmt", lsp_format = "fallback" },

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -1,0 +1,22 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        clangd = {
+          filetypes = { "c", "cpp", "objc", "objcpp", "cuda", "proto" },
+          cmd = {
+            "clangd",
+            "--background-index",
+            "--clang-tidy",
+            "--header-insertion=iwyu",
+            "--completion-style=detailed",
+            "--function-arg-placeholders",
+            "--fallback-style=llvm",
+            "--query-driver=/usr/local/cuda*/bin/nvcc",
+          },
+        },
+      },
+    },
+  },
+}

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -8,6 +8,7 @@ return {
         "c",
         "cmake",
         "cpp",
+        "cuda",
         "go",
         "gomod",
         "gowork",


### PR DESCRIPTION
This PR syncs the CUDA-related Neovim configuration from the working local `~/.config/nvim` setup into the tracked `nvim/` directory in this repository.

The issue was that the repo copy of the Neovim config lagged behind the live configuration that was already working for CUDA development. As a result, the checked-in config was missing the LazyVim `clangd` extra, CUDA Treesitter support, the `clangd` override needed to attach to `cuda` buffers, and the CUDA-specific editor commands and keymaps used for navigating related files and running CUDA test/debug flows.

The root cause was simply drift between the local runtime config and the versioned copy in `Vim-Stuff`. That meant the repo no longer represented the current CUDA editing workflow, and anyone restoring or sharing the tracked config would miss the CUDA-specific behavior.

This change brings the tracked config back in line by enabling the LazyVim `clangd` extra, adding the `cuda` Treesitter parser, wiring `clang_format` for CUDA buffers through Conform, adding the `nvim-lspconfig` override so `clangd` handles `cuda` filetypes with the expected command-line flags, and adding the CUDA helper module plus the associated autocmd and keymap wiring. The helper module provides project-root detection, alternate-file jumps, CUDA test commands, hardware verification, and a `cuda-gdb` debug entry point consistent with the working local setup.

Validation was intentionally lightweight and focused on syntax because this repository also has unrelated local modifications that were not included in this PR. The updated Lua files were checked with `luac -p` to ensure the synced config parses cleanly.

Validation:

- `luac -p nvim/lua/plugins/nvim-lspconfig.lua`
- `luac -p nvim/lua/config/cuda.lua`
- `luac -p nvim/lua/config/autocmds.lua`
- `luac -p nvim/lua/config/keymaps.lua`
- `luac -p nvim/lua/plugins/treesitter.lua`
- `luac -p nvim/lua/plugins/conform.lua`

This PR includes only the CUDA/clangd Neovim sync files and intentionally excludes other unrelated working-tree changes already present in the repository.
